### PR TITLE
Fix painful file name

### DIFF
--- a/requestToUsage/requestToUsage.sh
+++ b/requestToUsage/requestToUsage.sh
@@ -5,7 +5,7 @@ if [ ! -f $FILE ]; then
 fi
 PREFIX=$2
 
-OUTPUT=$PREFIX-$(head -c 8 $FILE).csv
+OUTPUT=${PREFIX:+${PREFIX}-}$(head -c 8 $FILE).csv
 
 awk '!/0$/' $FILE > $OUTPUT
 if sed --version 


### PR DESCRIPTION
If `$PREFIX` was null there was still a `-` prepended to the filename which is annoying to open/remove in Linux without using `--` after your command.