### PR TITLE
Fix multiLog parsing logic

### DIFF
--- a/requestToUsage/multiLogParse.sh
+++ b/requestToUsage/multiLogParse.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 LOC=$1
-if [ ! -f $LOC ]; then
-    echo "Correct usage is: requestToUsage.sh request.log"
+${LOC:-"."}
+if [ ! -d $LOC ]; then
+    echo "Usage is: ./multiLogParse.sh /path/to/logs/ <OPTIONAL_PREFIX>"
+else
+    echo "Using directory $LOC as LOC"
 fi
 PREFIX=$2
-for i in $LOC; do 
+for i in $LOC/request.*; do
 	./requestToUsage.sh $i $PREFIX
 done


### PR DESCRIPTION
If they don't pass a LOC they probably want the current directory, warn if the passed LOC isn't a directory.