### PR TITLE
Use urllib.parse.quote to parse artifact name that contains space

### DIFF
--- a/filestoreIntegrity/filestoreIntegrity.py
+++ b/filestoreIntegrity/filestoreIntegrity.py
@@ -4,6 +4,7 @@ import json
 import base64
 import getpass
 import argparse
+import urllib
 import urllib.request
 import urllib.error
 
@@ -22,7 +23,7 @@ def runCheck(conn, outfile):
     with outf:
         for repo in getRepoList(conn):
             for artif in getArtifactList(conn, repo):
-                response = checkArtifact(conn, repo, artif)
+                response = checkArtifact(conn, repo, urllib.parse.quote(artif))
                 if response != None:
                     count += 1
                     print(response, file=outf)


### PR DESCRIPTION
For artifacts that contains "space" in their name, this script will throw a "[400 Bad Request]" and consider it as a conspicuous artifact. This is not 100% true.

I would use "urllib.parse.quote" for artifact name parsing.