### PR TITLE
Optional verbose logging for filestoreIntegrity.py

### DIFF
--- a/filestoreIntegrity/filestoreIntegrity.py
+++ b/filestoreIntegrity/filestoreIntegrity.py
@@ -6,6 +6,11 @@ import getpass
 import argparse
 import urllib.request
 import urllib.error
+import logging
+
+FORMAT = "[%(asctime)s %(levelname)s] %(message)s"
+logging.basicConfig(level=logging.WARNING, format=FORMAT)
+logger = logging.getLogger()
 
 # check the integrity, and print the results to stdout or the specified file
 def runCheck(conn, outfile):
@@ -21,7 +26,9 @@ def runCheck(conn, outfile):
     # iterate through every artifact, and print the ones that don't check
     with outf:
         for repo in getRepoList(conn):
+            logger.debug('Checking repository: %s', repo)
             for artif in getArtifactList(conn, repo):
+                logger.debug('Checking: repo=%s artifact=%s', repo, artif)
                 response = checkArtifact(conn, repo, artif)
                 if response != None:
                     count += 1
@@ -33,20 +40,28 @@ def runCheck(conn, outfile):
 
 # request a list of all local repositories, and return them
 def getRepoList(conn):
+    logger.debug('Listing repositories...')
     stat, msg = runRequest(conn, '/api/repositories?type=local')
     if stat != 200:
         print('Error getting repository list: {}'.format(msg), file=sys.stderr)
         sys.exit(1)
-    return map(lambda x: x['key'], json.loads(msg.decode("utf-8")))
+    res = list(map(lambda x: x['key'], json.loads(msg.decode("utf-8"))))
+    logger.debug('Found %d repositories', len(res))
+    return res
 
 # request a list of all artifacts in a repository, and return them
 def getArtifactList(conn, repo):
+    logger.debug('Listing artifacts in repository: %s', repo)
     stat, msg = runRequest(conn, '/api/storage/{}?list&deep=1'.format(repo))
     if stat != 200:
         err = "Error getting artifact list for '{}': {}".format(repo, msg)
         print(err, file=sys.stderr)
         sys.exit(1)
-    return map(lambda x: x['uri'], json.loads(msg.decode("utf-8"))['files'])
+    res = list(
+        map(lambda x: x['uri'], json.loads(msg.decode("utf-8"))['files'])
+    )
+    logger.debug('Found %d artifacts in repository: %s', len(res), repo)
+    return res
 
 # request an artifact, and return a summary of the artifact if the response code
 # wasn't 200 or 404
@@ -93,19 +108,27 @@ def getArgs():
         "Check Artifactory for filestore integrity.",
         "the Artifactory base url",
         "your Artifactory username (or username:password)",
-        "output to the given file, rather than to stdout"
+        "output to the given file, rather than to stdout",
+        "log verbose output while retrieving artifacts"
     ]
     parser = argparse.ArgumentParser(description=help[0])
     parser.add_argument('url', nargs=1, help=help[1])
     parser.add_argument('-u', '--user', help=help[2])
     parser.add_argument('-o', '--output-file', help=help[3])
+    parser.add_argument(
+        '-v', '--verbose', dest='verbose', help=help[4], action='store_true',
+        default=False
+    )
     return parser.parse_args()
 
 if __name__ == "__main__":
     # get the base url and the authentication information from the commandline,
     # and start the integrity check
     args = getArgs()
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     auth = getAuth(args.user)
     urlbase = args.url[0]
     if urlbase[-1] == '/': urlbase = urlbase[:-1]
+    logger.debug('Running against: %s', urlbase)
     runCheck((urlbase, auth), args.output_file)


### PR DESCRIPTION
The filestoreIntegrity.py script as currently written doesn't produce any output at all unless it finds a problem with an artifact. When running it against an Artifactory instance with 24 local repositories and over 275,000 artifacts, it just hangs silently at the command line with no indication that it's doing anything at all.

This PR adds a logger to the script and debug-level log messages for each repository and artifact that the script checks. This logging is not present by default, but is enabled by the `-v` or `--verbose` arguments.